### PR TITLE
[TASK] Align with new TYPO3 documentation standards (follow-up)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Latest Stable Version](https://poser.pugx.org/friendsoftypo3/rdct/v/stable.svg)](https://extensions.typo3.org/extension/rdct/)
-[![TYPO3](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
-[![TYPO3](https://img.shields.io/badge/TYPO3-9-orange.svg?style=flat-square)](https://get.typo3.org/version/9)
+[![TYPO3 10](https://img.shields.io/badge/TYPO3-10-orange.svg?style=flat-square)](https://get.typo3.org/version/10)
+[![TYPO3 9](https://img.shields.io/badge/TYPO3-9-orange.svg?style=flat-square)](https://get.typo3.org/version/9)
 [![Total Downloads](https://poser.pugx.org/friendsoftypo3/rdct/d/total.svg)](https://packagist.org/packages/friendsoftypo3/rdct)
 [![Monthly Downloads](https://poser.pugx.org/friendsoftypo3/rdct/d/monthly)](https://packagist.org/packages/friendsoftypo3/rdct)
 

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,12 @@
 	"name": "friendsoftypo3/rdct",
 	"type": "typo3-cms-extension",
 	"description": "Frontend redirects based on RDCT GET parameter",
-	"homepage": "https://typo3.org",
+	"homepage": "https://extensions.typo3.org/extension/rdct",
+	"support": {
+		"docs": "https://docs.typo3.org/p/friendsoftypo3/rdct/main/en-us/",
+		"issues": "https://github.com/FriendsOfTYPO3/rdct/issues",
+		"source": "https://github.com/FriendsOfTYPO3/rdct"
+	},
 	"license": ["GPL-2.0+"],
 	"authors": [
 		{


### PR DESCRIPTION
Added new commit regarding additional sources (TER, repository and docs.typo3.org) in composer.json.

What is missing:
(1) Registering this documentation for rendering and publishing at docs.typo3.org with the [webhook](https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingDocForExtension/Webhook.html#github).
(2) Remove any documentation URL from the "External manual" field of the TER extension page configuration at https://extensions.typo3.org as the documentation at docs.typo3.org is detected automatically and a specific URL is error-prone.
(3) Add the "Found an issue?" button, which seem to be caused by the empty "Link to issue tracker" field in the TER extension edit form.

Relates: TYPO3-Documentation/T3DocTeam#185